### PR TITLE
Add unit tests for RDFTripleKey

### DIFF
--- a/src/GraphlessDB.Tests/Storage.Tests/RDFTripleKeyTests.cs
+++ b/src/GraphlessDB.Tests/Storage.Tests/RDFTripleKeyTests.cs
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+using System;
+using GraphlessDB.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GraphlessDB.Storage.Tests
+{
+    [TestClass]
+    public sealed class RDFTripleKeyTests
+    {
+        [TestMethod]
+        public void CanCompareToWithEqualKeys()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1.CompareTo(key2);
+
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void CanCompareToWithLessThanBySubject()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject2", "predicate1");
+
+            var result = key1.CompareTo(key2);
+
+            Assert.IsTrue(result < 0);
+        }
+
+        [TestMethod]
+        public void CanCompareToWithGreaterThanBySubject()
+        {
+            var key1 = new RDFTripleKey("subject2", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1.CompareTo(key2);
+
+            Assert.IsTrue(result > 0);
+        }
+
+        [TestMethod]
+        public void CanCompareToWithLessThanByPredicate()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate2");
+
+            var result = key1.CompareTo(key2);
+
+            Assert.IsTrue(result < 0);
+        }
+
+        [TestMethod]
+        public void CanCompareToWithGreaterThanByPredicate()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate2");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1.CompareTo(key2);
+
+            Assert.IsTrue(result > 0);
+        }
+
+        [TestMethod]
+        public void CanCompareToWithNull()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1.CompareTo(null);
+
+            Assert.IsTrue(result > 0);
+        }
+
+        [TestMethod]
+        public void CanUseLessThanOperator()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject2", "predicate1");
+
+            var result = key1 < key2;
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CanUseLessThanOperatorReturnsFalse()
+        {
+            var key1 = new RDFTripleKey("subject2", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1 < key2;
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void CanUseGreaterThanOperator()
+        {
+            var key1 = new RDFTripleKey("subject2", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1 > key2;
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CanUseGreaterThanOperatorReturnsFalse()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject2", "predicate1");
+
+            var result = key1 > key2;
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void CanUseLessThanOrEqualOperator()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject2", "predicate1");
+
+            var result = key1 <= key2;
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CanUseLessThanOrEqualOperatorWithEqualKeys()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1 <= key2;
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CanUseLessThanOrEqualOperatorReturnsFalse()
+        {
+            var key1 = new RDFTripleKey("subject2", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1 <= key2;
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void CanUseGreaterThanOrEqualOperator()
+        {
+            var key1 = new RDFTripleKey("subject2", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1 >= key2;
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CanUseGreaterThanOrEqualOperatorWithEqualKeys()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject1", "predicate1");
+
+            var result = key1 >= key2;
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CanUseGreaterThanOrEqualOperatorReturnsFalse()
+        {
+            var key1 = new RDFTripleKey("subject1", "predicate1");
+            var key2 = new RDFTripleKey("subject2", "predicate1");
+
+            var result = key1 >= key2;
+
+            Assert.IsFalse(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for the `RDFTripleKey` class to achieve 100% code coverage.

## Changes
- Created test suite in `src/GraphlessDB.Tests/Storage.Tests/RDFTripleKeyTests.cs`
- Added 16 test methods covering:
  - `CompareTo` method with various scenarios (equal, less than, greater than, null)
  - All comparison operators: `<`, `>`, `<=`, `>=`
  - Edge cases for both subject and predicate comparisons

## Test Results
-  All 16 tests passing
-  100% code coverage achieved (14/14 lines covered, 0 lines not covered)

## Solution Coverage
- Line Coverage: 35.44%
- Branch Coverage: 31.59%

Closes #62