### PR TITLE
Add unit tests for GraphlessDBIdempotentRequestMismatchException

### DIFF
--- a/src/GraphlessDB.Tests/Tests/GraphlessDBIdempotentRequestMismatchExceptionTests.cs
+++ b/src/GraphlessDB.Tests/Tests/GraphlessDBIdempotentRequestMismatchExceptionTests.cs
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+using System;
+using GraphlessDB;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GraphlessDB.Tests
+{
+    [TestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method names are more readable with underscores")]
+    public sealed class GraphlessDBIdempotentRequestMismatchExceptionTests
+    {
+        [TestMethod]
+        public void ConstructorWithNoParametersCreatesException()
+        {
+            var exception = new GraphlessDBIdempotentRequestMismatchException();
+            Assert.IsNotNull(exception);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageSetsMessageProperty()
+        {
+            var message = "Test message";
+            var exception = new GraphlessDBIdempotentRequestMismatchException(message);
+            Assert.AreEqual(message, exception.Message);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageAndInnerExceptionSetsProperties()
+        {
+            var message = "Test message";
+            var innerException = new InvalidOperationException("Inner exception");
+            var exception = new GraphlessDBIdempotentRequestMismatchException(message, innerException);
+            Assert.AreEqual(message, exception.Message);
+            Assert.AreEqual(innerException, exception.InnerException);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #148

This PR adds comprehensive unit tests for the `GraphlessDBIdempotentRequestMismatchException` class, achieving 100% code coverage.

## Tests Added
- Constructor with no parameters
- Constructor with message parameter
- Constructor with message and inner exception parameters

## Coverage Results
- **File Coverage**: 100% (2/2 lines covered)
- **Solution Coverage**: Line: 48.28%, Branch: 40.73%

All tests pass successfully.