### PR TITLE
Add unit tests for GraphlessDBInternalServerErrorException - 100% coverage

### DIFF
--- a/src/GraphlessDB.Tests/Tests/GraphlessDBInternalServerErrorExceptionTests.cs
+++ b/src/GraphlessDB.Tests/Tests/GraphlessDBInternalServerErrorExceptionTests.cs
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+using System;
+using GraphlessDB;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GraphlessDB.Tests
+{
+    [TestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method names are more readable with underscores")]
+    public sealed class GraphlessDBInternalServerErrorExceptionTests
+    {
+        [TestMethod]
+        public void ConstructorWithNoParametersCreatesException()
+        {
+            var exception = new GraphlessDBInternalServerErrorException();
+            Assert.IsNotNull(exception);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageSetsMessageProperty()
+        {
+            var message = "Test message";
+            var exception = new GraphlessDBInternalServerErrorException(message);
+            Assert.AreEqual(message, exception.Message);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageAndInnerExceptionSetsProperties()
+        {
+            var message = "Test message";
+            var innerException = new InvalidOperationException("Inner exception");
+            var exception = new GraphlessDBInternalServerErrorException(message, innerException);
+            Assert.AreEqual(message, exception.Message);
+            Assert.AreEqual(innerException, exception.InnerException);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #149

## Changes
- Created unit tests for GraphlessDBInternalServerErrorException
- Achieved 100% code coverage for the exception class

## Coverage
- **Line Coverage**: 47.07%
- **Branch Coverage**: 40.41%

## Test Coverage for GraphlessDBInternalServerErrorException
- Lines covered: 2
- Lines not covered: 0
- Coverage percentage: 100.00%