### PR TITLE
Add unit tests for GraphlessDBRequestLimitExceededException - 100% coverage

### DIFF
--- a/src/GraphlessDB.Tests/Tests/GraphlessDBRequestLimitExceededExceptionTests.cs
+++ b/src/GraphlessDB.Tests/Tests/GraphlessDBRequestLimitExceededExceptionTests.cs
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+using System;
+using GraphlessDB;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GraphlessDB.Tests
+{
+    [TestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method names are more readable with underscores")]
+    public sealed class GraphlessDBRequestLimitExceededExceptionTests
+    {
+        [TestMethod]
+        public void ConstructorWithNoParametersCreatesException()
+        {
+            var exception = new GraphlessDBRequestLimitExceededException();
+            Assert.IsNotNull(exception);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageSetsMessageProperty()
+        {
+            var message = "Test message";
+            var exception = new GraphlessDBRequestLimitExceededException(message);
+            Assert.AreEqual(message, exception.Message);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageAndInnerExceptionSetsProperties()
+        {
+            var message = "Test message";
+            var innerException = new InvalidOperationException("Inner exception");
+            var exception = new GraphlessDBRequestLimitExceededException(message, innerException);
+            Assert.AreEqual(message, exception.Message);
+            Assert.AreEqual(innerException, exception.InnerException);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for GraphlessDBRequestLimitExceededException, achieving 100% coverage.

**Tests Added:**
- Constructor with no parameters
- Constructor with message parameter
- Constructor with message and inner exception parameters

**Coverage Results:**
- File coverage: 100% (2/2 lines covered)
- Solution coverage: 47.06% line coverage, 40.36% branch coverage

Closes #150