### PR TITLE
Add unit tests for GraphlessDBResourceNotFoundException - 100% coverage

### DIFF
--- a/src/GraphlessDB.Tests/Tests/GraphlessDBResourceNotFoundExceptionTests.cs
+++ b/src/GraphlessDB.Tests/Tests/GraphlessDBResourceNotFoundExceptionTests.cs
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+using System;
+using GraphlessDB;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GraphlessDB.Tests
+{
+    [TestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method names are more readable with underscores")]
+    public sealed class GraphlessDBResourceNotFoundExceptionTests
+    {
+        [TestMethod]
+        public void ConstructorWithNoParametersCreatesException()
+        {
+            var exception = new GraphlessDBResourceNotFoundException();
+            Assert.IsNotNull(exception);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageSetsMessageProperty()
+        {
+            var message = "Test message";
+            var exception = new GraphlessDBResourceNotFoundException(message);
+            Assert.AreEqual(message, exception.Message);
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void ConstructorWithMessageAndInnerExceptionSetsProperties()
+        {
+            var message = "Test message";
+            var innerException = new InvalidOperationException("Inner exception");
+            var exception = new GraphlessDBResourceNotFoundException(message, innerException);
+            Assert.AreEqual(message, exception.Message);
+            Assert.AreEqual(innerException, exception.InnerException);
+        }
+    }
+}


### PR DESCRIPTION
Closes #151

Added comprehensive unit tests for GraphlessDBResourceNotFoundException covering all constructor overloads:
- Constructor with no parameters
- Constructor with message parameter
- Constructor with message and inner exception parameters

**Coverage:**
- GraphlessDBResourceNotFoundException.cs: 100% (2/2 lines covered)

**Solution Coverage:**
- Line Coverage: 47.06%
- Branch Coverage: 40.36%