### PR TITLE
Add unit tests for PageInfoExtensions - Issue #254

### DIFF
--- a/src/GraphlessDB.Tests/Tests/PageInfoExtensionsTests.cs
+++ b/src/GraphlessDB.Tests/Tests/PageInfoExtensionsTests.cs
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+using GraphlessDB;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GraphlessDB.Tests
+{
+    [TestClass]
+    public sealed class PageInfoExtensionsTests
+    {
+        [TestMethod]
+        public void GetNullableStartCursorReturnsNullWhenStartCursorIsNull()
+        {
+            // Arrange
+            var pageInfo = new PageInfo(false, false, null!, string.Empty);
+
+            // Act
+            var result = pageInfo.GetNullableStartCursor();
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetNullableStartCursorReturnsNullWhenStartCursorIsEmpty()
+        {
+            // Arrange
+            var pageInfo = new PageInfo(false, false, string.Empty, string.Empty);
+
+            // Act
+            var result = pageInfo.GetNullableStartCursor();
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetNullableStartCursorReturnsValueWhenStartCursorHasValue()
+        {
+            // Arrange
+            var pageInfo = new PageInfo(false, false, "cursor1", string.Empty);
+
+            // Act
+            var result = pageInfo.GetNullableStartCursor();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("cursor1", result);
+        }
+
+        [TestMethod]
+        public void GetNullableEndCursorReturnsNullWhenEndCursorIsNull()
+        {
+            // Arrange
+            var pageInfo = new PageInfo(false, false, string.Empty, null!);
+
+            // Act
+            var result = pageInfo.GetNullableEndCursor();
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetNullableEndCursorReturnsNullWhenEndCursorIsEmpty()
+        {
+            // Arrange
+            var pageInfo = new PageInfo(false, false, string.Empty, string.Empty);
+
+            // Act
+            var result = pageInfo.GetNullableEndCursor();
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetNullableEndCursorReturnsValueWhenEndCursorHasValue()
+        {
+            // Arrange
+            var pageInfo = new PageInfo(false, false, string.Empty, "cursor2");
+
+            // Act
+            var result = pageInfo.GetNullableEndCursor();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("cursor2", result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for the `PageInfoExtensions` class to achieve 100% code coverage.

## Changes
- Added `PageInfoExtensionsTests.cs` with 6 test methods covering all code paths
- Tests cover both `GetNullableStartCursor` and `GetNullableEndCursor` methods
- Edge cases tested: null values, empty strings, and valid cursor values

## Coverage Results
- **File Coverage:** 100% (20/20 lines covered)
- **Solution Coverage:**
  - Line Coverage: 56.49%
  - Branch Coverage: 49.47%

Closes #254