### PR TITLE
Improve unit test coverage for NodeConnectionQueryExecutor - achieve 100% coverage

### DIFF
--- a/src/GraphlessDB.Tests/Query.Services.Internal.Tests/NodeConnectionQueryExecutorTests.cs
+++ b/src/GraphlessDB.Tests/Query.Services.Internal.Tests/NodeConnectionQueryExecutorTests.cs
@@ -166,10 +166,44 @@ namespace GraphlessDB.Query.Services.Internal.Tests
         private sealed class MockGraphQueryService : IGraphQueryService
         {
             private readonly Dictionary<string, INode> nodes = new();
+            private Connection<RelayEdge<INode>, INode>? connectionByTypeResponse;
+            private Connection<RelayEdge<INode>, INode>? connectionByTypeAndPropertyNameResponse;
+            private Connection<RelayEdge<INode>, INode>? connectionByTypePropertyNameAndValueResponse;
+            private Connection<RelayEdge<INode>, INode>? connectionByTypePropertyNameAndValuesResponse;
+            private Func<Connection<RelayEdge<INode>, INode>>? connectionCallback;
+
+            public bool GetConnectionByTypeAndPropertyNameAsyncCalled { get; private set; }
+            public bool GetConnectionByTypePropertyNameAndValueAsyncCalled { get; private set; }
+            public bool GetConnectionByTypePropertyNameAndValuesAsyncCalled { get; private set; }
 
             public void SetNode(string id, INode node)
             {
                 nodes[id] = node;
+            }
+
+            public void SetConnectionByTypeResponse(Connection<RelayEdge<INode>, INode> connection)
+            {
+                connectionByTypeResponse = connection;
+            }
+
+            public void SetConnectionByTypeAndPropertyNameResponse(Connection<RelayEdge<INode>, INode> connection)
+            {
+                connectionByTypeAndPropertyNameResponse = connection;
+            }
+
+            public void SetConnectionByTypePropertyNameAndValueResponse(Connection<RelayEdge<INode>, INode> connection)
+            {
+                connectionByTypePropertyNameAndValueResponse = connection;
+            }
+
+            public void SetConnectionByTypePropertyNameAndValuesResponse(Connection<RelayEdge<INode>, INode> connection)
+            {
+                connectionByTypePropertyNameAndValuesResponse = connection;
+            }
+
+            public void SetConnectionCallback(Func<Connection<RelayEdge<INode>, INode>> callback)
+            {
+                connectionCallback = callback;
             }
 
             public Task ClearAsync(CancellationToken cancellationToken)
@@ -208,22 +242,26 @@ namespace GraphlessDB.Query.Services.Internal.Tests
 
             public Task<GetConnectionResponse> GetConnectionByTypeAsync(GetConnectionByTypeRequest request, CancellationToken cancellationToken)
             {
-                return Task.FromResult(new GetConnectionResponse(Connection<RelayEdge<INode>, INode>.Empty));
+                var response = connectionCallback?.Invoke() ?? connectionByTypeResponse ?? Connection<RelayEdge<INode>, INode>.Empty;
+                return Task.FromResult(new GetConnectionResponse(response));
             }
 
             public Task<GetConnectionResponse> GetConnectionByTypeAndPropertyNameAsync(GetConnectionByTypeAndPropertyNameRequest request, CancellationToken cancellationToken)
             {
-                return Task.FromResult(new GetConnectionResponse(Connection<RelayEdge<INode>, INode>.Empty));
+                GetConnectionByTypeAndPropertyNameAsyncCalled = true;
+                return Task.FromResult(new GetConnectionResponse(connectionByTypeAndPropertyNameResponse ?? Connection<RelayEdge<INode>, INode>.Empty));
             }
 
             public Task<GetConnectionResponse> GetConnectionByTypePropertyNameAndValueAsync(GetConnectionByTypePropertyNameAndValueRequest request, CancellationToken cancellationToken)
             {
-                return Task.FromResult(new GetConnectionResponse(Connection<RelayEdge<INode>, INode>.Empty));
+                GetConnectionByTypePropertyNameAndValueAsyncCalled = true;
+                return Task.FromResult(new GetConnectionResponse(connectionByTypePropertyNameAndValueResponse ?? Connection<RelayEdge<INode>, INode>.Empty));
             }
 
             public Task<GetConnectionResponse> GetConnectionByTypePropertyNameAndValuesAsync(GetConnectionByTypePropertyNameAndValuesRequest request, CancellationToken cancellationToken)
             {
-                return Task.FromResult(new GetConnectionResponse(Connection<RelayEdge<INode>, INode>.Empty));
+                GetConnectionByTypePropertyNameAndValuesAsyncCalled = true;
+                return Task.FromResult(new GetConnectionResponse(connectionByTypePropertyNameAndValuesResponse ?? Connection<RelayEdge<INode>, INode>.Empty));
             }
 
             public Task<ToEdgeQueryResponse> GetInToEdgeConnectionAsync(ToEdgeQueryRequest request, CancellationToken cancellationToken)
@@ -249,9 +287,22 @@ namespace GraphlessDB.Query.Services.Internal.Tests
 
         private sealed class MockNodeFilterService : IGraphNodeFilterService
         {
+            private bool isPostFilteringRequired;
+            private NodePushdownQueryData? pushdownQueryData;
+
+            public void SetPostFilteringRequired(bool value)
+            {
+                isPostFilteringRequired = value;
+            }
+
+            public void SetPushdownQueryData(NodePushdownQueryData? data)
+            {
+                pushdownQueryData = data;
+            }
+
             public bool IsPostFilteringRequired(INodeFilter? filter)
             {
-                return false;
+                return isPostFilteringRequired;
             }
 
             public NodePushdownQueryData? TryGetNodePushdownQueryData(
@@ -260,7 +311,7 @@ namespace GraphlessDB.Query.Services.Internal.Tests
                 INodeOrder? order,
                 CancellationToken cancellationToken)
             {
-                return null;
+                return pushdownQueryData;
             }
 
             public Task<bool> IsFilterMatchAsync(
@@ -271,6 +322,384 @@ namespace GraphlessDB.Query.Services.Internal.Tests
             {
                 return Task.FromResult(true);
             }
+
+            public static Task<Connection<RelayEdge<INode>, INode>> GetFilteredNodeConnectionAsync(
+                Connection<RelayEdge<INode>, INode> connection,
+                INodeFilter? filter,
+                bool consistentRead,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(connection);
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncWithCursorContainingChildNodesThrowsException()
+        {
+            var cancellationToken = GetCancellationToken();
+            var nodeId = "node123";
+            var childKey = "childKey";
+            var parentKey = "parentKey";
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var hasTypeCursor = new HasTypeCursor(nodeId, "partition1", ImmutableList<HasTypeCursorQueryCursor>.Empty);
+            var cursorNode = new CursorNode(hasTypeCursor, null, null, null, null, null, null, null);
+            var baseCursor = Cursor.Create(cursorNode);
+            var childCursorNode = new CursorNode(hasTypeCursor, null, null, null, null, null, null, null);
+            var cursorWithChild = baseCursor.AddChildNode(childCursorNode, baseCursor.GetRootKey(), out _);
+            var cursor = cursorSerializer.Serialize(cursorWithChild);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, cursor, null, null), 25, false, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(childKey, new GraphQueryNode(query))
+                .AddParentNode(childKey, parentKey, new GraphQueryNode(new NodeConnectionQuery("User", null, null, ConnectionArguments.Default, 25, false, null)));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            await Assert.ThrowsExceptionAsync<GraphlessDBOperationException>(
+                async () => await executor.ExecuteAsync(context, childKey, cancellationToken));
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncWithCursorMissingSubjectThrowsException()
+        {
+            var cancellationToken = GetCancellationToken();
+            var childKey = "childKey";
+            var parentKey = "parentKey";
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var cursorNode = new CursorNode(null, null, null, null, null, null, null, null);
+            var cursor = cursorSerializer.Serialize(Cursor.Create(cursorNode));
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, cursor, null, null), 25, false, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(childKey, new GraphQueryNode(query))
+                .AddParentNode(childKey, parentKey, new GraphQueryNode(new NodeConnectionQuery("User", null, null, ConnectionArguments.Default, 25, false, null)));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            await Assert.ThrowsExceptionAsync<GraphlessDBOperationException>(
+                async () => await executor.ExecuteAsync(context, childKey, cancellationToken));
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncTruncatesResultsWhenDeltaCountExceedsPageSize()
+        {
+            var cancellationToken = GetCancellationToken();
+            var key = string.Empty;
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var edges = new List<RelayEdge<INode>>();
+            for (int i = 0; i < 15; i++)
+            {
+                var node = MockNode.Create($"node{i}");
+                var hasTypeCursor = new HasTypeCursor($"node{i}", "partition1", ImmutableList<HasTypeCursorQueryCursor>.Empty);
+                var cursorNode = new CursorNode(hasTypeCursor, null, null, null, null, null, null, null);
+                var cursor = cursorSerializer.Serialize(Cursor.Create(cursorNode));
+                edges.Add(new RelayEdge<INode>(cursor, node));
+            }
+
+            var connection = new Connection<RelayEdge<INode>, INode>(
+                edges.ToImmutableList(),
+                new PageInfo(true, false, edges[0].Cursor, edges[^1].Cursor));
+
+            graphQueryService.SetConnectionByTypeResponse(connection);
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, null, null, null), 25, true, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(key, new GraphQueryNode(query));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            var resultContext = await executor.ExecuteAsync(context, key, cancellationToken);
+
+            Assert.IsNotNull(resultContext);
+            var result = resultContext.TryGetResult<NodeConnectionResult>(key);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(10, result.Connection.Edges.Count);
+            Assert.IsTrue(result.Connection.PageInfo.HasNextPage);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncTruncatesFinalResultForRootQueryWhenOverFetching()
+        {
+            var cancellationToken = GetCancellationToken();
+            var key = string.Empty;
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var firstBatchEdges = new List<RelayEdge<INode>>();
+            for (int i = 0; i < 8; i++)
+            {
+                var node = MockNode.Create($"node{i}");
+                var hasTypeCursor = new HasTypeCursor($"node{i}", "partition1", ImmutableList<HasTypeCursorQueryCursor>.Empty);
+                var cursorNode = new CursorNode(hasTypeCursor, null, null, null, null, null, null, null);
+                var cursor = cursorSerializer.Serialize(Cursor.Create(cursorNode));
+                firstBatchEdges.Add(new RelayEdge<INode>(cursor, node));
+            }
+
+            var secondBatchEdges = new List<RelayEdge<INode>>();
+            for (int i = 8; i < 15; i++)
+            {
+                var node = MockNode.Create($"node{i}");
+                var hasTypeCursor = new HasTypeCursor($"node{i}", "partition1", ImmutableList<HasTypeCursorQueryCursor>.Empty);
+                var cursorNode = new CursorNode(hasTypeCursor, null, null, null, null, null, null, null);
+                var cursor = cursorSerializer.Serialize(Cursor.Create(cursorNode));
+                secondBatchEdges.Add(new RelayEdge<INode>(cursor, node));
+            }
+
+            var callCount = 0;
+            var firstConnection = new Connection<RelayEdge<INode>, INode>(
+                firstBatchEdges.ToImmutableList(),
+                new PageInfo(true, false, firstBatchEdges[0].Cursor, firstBatchEdges[^1].Cursor));
+
+            var secondConnection = new Connection<RelayEdge<INode>, INode>(
+                secondBatchEdges.ToImmutableList(),
+                new PageInfo(false, false, secondBatchEdges[0].Cursor, secondBatchEdges[^1].Cursor));
+
+            graphQueryService.SetConnectionCallback(() =>
+            {
+                callCount++;
+                return callCount == 1 ? firstConnection : secondConnection;
+            });
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, null, null, null), 25, true, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(key, new GraphQueryNode(query));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            var resultContext = await executor.ExecuteAsync(context, key, cancellationToken);
+
+            Assert.IsNotNull(resultContext);
+            var result = resultContext.TryGetResult<NodeConnectionResult>(key);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(10, result.Connection.Edges.Count);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncWithMultiValuePropertyFilter()
+        {
+            var cancellationToken = GetCancellationToken();
+            var key = string.Empty;
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var propertyValues = ImmutableList<string>.Empty
+                .Add("value1")
+                .Add("value2");
+
+            var filterData = new NodeFilterArguments(PropertyOperator.Equals, propertyValues);
+            var orderData = new OrderArguments("name", OrderDirection.Asc);
+            var pushdownData = new NodePushdownQueryData(orderData, filterData);
+
+            nodeFilterService.SetPushdownQueryData(pushdownData);
+
+            var connection = Connection<RelayEdge<INode>, INode>.Empty;
+            graphQueryService.SetConnectionByTypePropertyNameAndValuesResponse(connection);
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, null, null, null), 25, true, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(key, new GraphQueryNode(query));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            var resultContext = await executor.ExecuteAsync(context, key, cancellationToken);
+
+            Assert.IsNotNull(resultContext);
+            Assert.IsTrue(graphQueryService.GetConnectionByTypePropertyNameAndValuesAsyncCalled);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncWithMultiValuePropertyFilterDescending()
+        {
+            var cancellationToken = GetCancellationToken();
+            var key = string.Empty;
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var propertyValues = ImmutableList<string>.Empty
+                .Add("value1")
+                .Add("value2");
+
+            var filterData = new NodeFilterArguments(PropertyOperator.Equals, propertyValues);
+            var orderData = new OrderArguments("name", OrderDirection.Desc);
+            var pushdownData = new NodePushdownQueryData(orderData, filterData);
+
+            nodeFilterService.SetPushdownQueryData(pushdownData);
+
+            var connection = Connection<RelayEdge<INode>, INode>.Empty;
+            graphQueryService.SetConnectionByTypePropertyNameAndValuesResponse(connection);
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, null, null, null), 25, true, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(key, new GraphQueryNode(query));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            var resultContext = await executor.ExecuteAsync(context, key, cancellationToken);
+
+            Assert.IsNotNull(resultContext);
+            Assert.IsTrue(graphQueryService.GetConnectionByTypePropertyNameAndValuesAsyncCalled);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncWithSingleValuePropertyFilter()
+        {
+            var cancellationToken = GetCancellationToken();
+            var key = string.Empty;
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var propertyValues = ImmutableList<string>.Empty
+                .Add("value1");
+
+            var filterData = new NodeFilterArguments(PropertyOperator.Equals, propertyValues);
+            var orderData = new OrderArguments("name", OrderDirection.Asc);
+            var pushdownData = new NodePushdownQueryData(orderData, filterData);
+
+            nodeFilterService.SetPushdownQueryData(pushdownData);
+
+            var connection = Connection<RelayEdge<INode>, INode>.Empty;
+            graphQueryService.SetConnectionByTypePropertyNameAndValueResponse(connection);
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, null, null, null), 25, true, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(key, new GraphQueryNode(query));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            var resultContext = await executor.ExecuteAsync(context, key, cancellationToken);
+
+            Assert.IsNotNull(resultContext);
+            Assert.IsTrue(graphQueryService.GetConnectionByTypePropertyNameAndValueAsyncCalled);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsyncWithOrderedQueryNoFilter()
+        {
+            var cancellationToken = GetCancellationToken();
+            var key = string.Empty;
+
+            var cursorSerializer = new GraphCursorSerializationService();
+            var graphQueryService = new MockGraphQueryService();
+            var nodeFilterService = new MockNodeFilterService();
+
+            var orderData = new OrderArguments("name", OrderDirection.Asc);
+            var pushdownData = new NodePushdownQueryData(orderData, null);
+
+            nodeFilterService.SetPushdownQueryData(pushdownData);
+
+            var connection = Connection<RelayEdge<INode>, INode>.Empty;
+            graphQueryService.SetConnectionByTypeAndPropertyNameResponse(connection);
+
+            var executor = new NodeConnectionQueryExecutor(
+                graphQueryService,
+                nodeFilterService,
+                cursorSerializer);
+
+            var query = new NodeConnectionQuery("User", null, null, new ConnectionArguments(10, null, null, null), 25, true, null);
+
+            var graphQuery = ImmutableTree<string, GraphQueryNode>
+                .Empty
+                .AddNode(key, new GraphQueryNode(query));
+
+            var context = new GraphExecutionContext(
+                new EmptyGraphQueryExecutionService(),
+                graphQuery,
+                ImmutableDictionary<string, GraphResult>.Empty);
+
+            var resultContext = await executor.ExecuteAsync(context, key, cancellationToken);
+
+            Assert.IsNotNull(resultContext);
+            Assert.IsTrue(graphQueryService.GetConnectionByTypeAndPropertyNameAsyncCalled);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses issue #322 by adding comprehensive unit tests for `NodeConnectionQueryExecutor` to achieve 100% line coverage.

## Changes
- Added tests for cursor restoration error handling:
  - Test for cursors containing child nodes (exception case)
  - Test for cursors missing subject reference (exception case)
- Added tests for result truncation logic:
  - Test for intermediate truncation when deltaCount exceeds page size
  - Test for final result truncation for root queries when over-fetching
- Added tests for different query execution paths:
  - Multi-value property filter execution (ascending and descending)
  - Single-value property filter execution
  - Ordered-only query execution (no filter)
- Enhanced mock classes:
  - Added callback support to MockGraphQueryService for dynamic responses
  - Added configurable pushdown query data support to MockNodeFilterService
  - Made GetFilteredNodeConnectionAsync static per project conventions

## Test Results
All 2,834 tests pass successfully:
- GraphlessDB.Tests: 1,969 tests passed
- GraphlessDB.DynamoDB.Tests: 865 tests passed

## Coverage Improvement
- **Before**: 89.76% (149 lines covered, 17 uncovered)
- **After**: 100% (166 lines covered, 0 uncovered)
- **Improvement**: +10.24 percentage points, +17 lines covered

## Solution Coverage
- Line Coverage: 59.74%
- Branch Coverage: 52.37%

## Related Issue
Closes #322